### PR TITLE
Lowering min sdk and code clean up

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -40,10 +40,9 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'com.google.android.material:material:1.2.0-alpha06'
-    implementation "androidx.appcompat:appcompat:1.2.0-beta01"
-    implementation "androidx.constraintlayout:constraintlayout:2.0.0-beta4"
+    implementation 'com.google.android.material:material:1.1.0'
+    implementation "androidx.appcompat:appcompat:1.1.0"
+    implementation "androidx.constraintlayout:constraintlayout:1.1.3"
 
     implementation 'net.alhazmy13:ummalqura-calendar-snapshots:1.1.13'
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -20,7 +20,7 @@ android {
     buildToolsVersion "29.0.3"
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 19
         targetSdkVersion 29
         versionCode 1
         versionName "1.0.2"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:1.1.0"
     implementation "androidx.constraintlayout:constraintlayout:1.1.3"
 
-    implementation 'net.alhazmy13:ummalqura-calendar-snapshots:1.1.13'
+    api 'net.alhazmy13:ummalqura-calendar-snapshots:1.1.13'
 
 }
 

--- a/library/src/main/java/net/alhazmy13/hijridatepicker/date/gregorian/MonthView.java
+++ b/library/src/main/java/net/alhazmy13/hijridatepicker/date/gregorian/MonthView.java
@@ -660,7 +660,7 @@ public abstract class MonthView extends View {
      * has focus
      */
     public CalendarDay getAccessibilityFocus() {
-        final int day = mTouchHelper.getFocusedVirtualView();
+        final int day = mTouchHelper.getAccessibilityFocusedVirtualViewId();
         if (day >= 0) {
             return new CalendarDay(mYear, mMonth, day);
         }
@@ -710,7 +710,7 @@ public abstract class MonthView extends View {
         }
 
         public void clearFocusedVirtualView() {
-            final int focusedVirtualView = getFocusedVirtualView();
+            final int focusedVirtualView = getAccessibilityFocusedVirtualViewId();
             if (focusedVirtualView != ExploreByTouchHelper.INVALID_ID) {
                 getAccessibilityNodeProvider(MonthView.this).performAction(
                         focusedVirtualView,

--- a/library/src/main/java/net/alhazmy13/hijridatepicker/date/hijri/MonthView.java
+++ b/library/src/main/java/net/alhazmy13/hijridatepicker/date/hijri/MonthView.java
@@ -663,7 +663,7 @@ public abstract class MonthView extends View {
      * has focus
      */
     public CalendarDay getAccessibilityFocus() {
-        final int day = mTouchHelper.getFocusedVirtualView();
+        final int day = mTouchHelper.getAccessibilityFocusedVirtualViewId();
         if (day >= 0) {
             return new CalendarDay(mYear, mMonth, day);
         }
@@ -713,7 +713,7 @@ public abstract class MonthView extends View {
         }
 
         public void clearFocusedVirtualView() {
-            final int focusedVirtualView = getFocusedVirtualView();
+            final int focusedVirtualView = getAccessibilityFocusedVirtualViewId();
             if (focusedVirtualView != ExploreByTouchHelper.INVALID_ID) {
                 getAccessibilityNodeProvider(MonthView.this).performAction(
                         focusedVirtualView,

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -28,5 +28,4 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.google.android.material:material:1.1.0'
     implementation "androidx.appcompat:appcompat:1.1.0"
-    implementation 'net.alhazmy13:ummalqura-calendar-snapshots:1.1.13'
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -26,8 +26,7 @@ android {
 dependencies {
     implementation project(':library')
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'com.google.android.material:material:1.2.0-alpha06'
-    implementation "androidx.appcompat:appcompat:1.2.0-beta01"
+    implementation 'com.google.android.material:material:1.1.0'
+    implementation "androidx.appcompat:appcompat:1.1.0"
     implementation 'net.alhazmy13:ummalqura-calendar-snapshots:1.1.13'
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "29.0.3"
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 19
         targetSdkVersion 29
         versionCode 1
         versionName "1.0.2"


### PR DESCRIPTION
lower min sdk to 19
replaced the calendar implementation with api . This avoid adding same ummalqura library while using it. 
When using the artifact. 
removed unwanted androidx libs
changed the androidx dependences to latest stable rather than alpha version